### PR TITLE
list: remove 'NA' sentinel for --config, switch to Option<String>

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -40,64 +40,70 @@ impl BCommand for ListCommand {
     }
 
     fn execute(&self, cli: &Cli, workspace: &mut Workspace) -> Result<(), BError> {
-        let config: String = self.get_arg_str(cli, "config", BCOMMAND)?;
+        let config: Option<String> = cli
+            .get_args()
+            .subcommand_matches(BCOMMAND)
+            .and_then(|m| m.get_one::<String>("config"))
+            .cloned();
         let ctx: bool = self.get_arg_flag(cli, "ctx", BCOMMAND)?;
 
-        if config == "NA" {
-            // default value if not specified
-            // If no config is specified then we will list all supported build configs
-            cli.stdout(format!("{:<25} {:<52}", "NAME", "DESCRIPTION"));
-            workspace
-                .build_configs()
-                .iter()
-                .for_each(|(path, description)| {
-                    cli.stdout(format!(
-                        "{:<25} - {:<50}",
-                        path.file_stem().unwrap().to_string_lossy(),
-                        description
-                    ));
-                });
-        } else {
-            // List all tasks for a build config
-            if workspace.valid_config(config.as_str()) {
-                workspace.expand_ctx()?;
-                cli.stdout(format!(
-                    "name: {}\narch: {}\nmachine: {}\ndescription: {}\n",
-                    workspace.config().build_data().name(),
-                    workspace.config().build_data().product().arch(),
-                    workspace.config().build_data().bitbake().machine(),
-                    workspace.config().build_data().product().description()
-                ));
-
-                if ctx {
-                    let variables: IndexMap<String, String> = workspace.context()?;
-                    cli.stdout("Context variables:".to_string());
-                    variables.iter().for_each(|(key, value)| {
-                        cli.stdout(format!("{}={}", key.to_ascii_uppercase(), value));
-                    });
-                } else {
-                    cli.stdout(format!(
-                        "{:<15} {:<56} {}",
-                        "NAME", "DESCRIPTION", "ENABLED/DISABLED"
-                    ));
-                    workspace.config().tasks().iter().for_each(|(_name, task)| {
+        match config {
+            None => {
+                // If no config is specified then we will list all supported build configs
+                cli.stdout(format!("{:<25} {:<52}", "NAME", "DESCRIPTION"));
+                workspace
+                    .build_configs()
+                    .iter()
+                    .for_each(|(path, description)| {
                         cli.stdout(format!(
-                            "{:<15} - {:<54} [{}]",
-                            task.data().name(),
-                            task.data().description(),
-                            if task.data().disabled() {
-                                "disabled"
-                            } else {
-                                "enabled"
-                            }
+                            "{:<25} - {:<50}",
+                            path.file_stem().unwrap().to_string_lossy(),
+                            description
                         ));
                     });
+            }
+            Some(name) => {
+                // List all tasks for a build config
+                if workspace.valid_config(name.as_str()) {
+                    workspace.expand_ctx()?;
+                    cli.stdout(format!(
+                        "name: {}\narch: {}\nmachine: {}\ndescription: {}\n",
+                        workspace.config().build_data().name(),
+                        workspace.config().build_data().product().arch(),
+                        workspace.config().build_data().bitbake().machine(),
+                        workspace.config().build_data().product().description()
+                    ));
+
+                    if ctx {
+                        let variables: IndexMap<String, String> = workspace.context()?;
+                        cli.stdout("Context variables:".to_string());
+                        variables.iter().for_each(|(key, value)| {
+                            cli.stdout(format!("{}={}", key.to_ascii_uppercase(), value));
+                        });
+                    } else {
+                        cli.stdout(format!(
+                            "{:<15} {:<56} {}",
+                            "NAME", "DESCRIPTION", "ENABLED/DISABLED"
+                        ));
+                        workspace.config().tasks().iter().for_each(|(_name, task)| {
+                            cli.stdout(format!(
+                                "{:<15} - {:<54} [{}]",
+                                task.data().name(),
+                                task.data().description(),
+                                if task.data().disabled() {
+                                    "disabled"
+                                } else {
+                                    "enabled"
+                                }
+                            ));
+                        });
+                    }
+                } else {
+                    return Err(BError::CliError(format!(
+                        "Unsupported build config '{}'",
+                        name
+                    )));
                 }
-            } else {
-                return Err(BError::CliError(format!(
-                    "Unsupported build config '{}'",
-                    config
-                )));
             }
         }
 
@@ -114,8 +120,7 @@ impl ListCommand {
                     .short('c')
                     .long("config")
                     .help("The build config defining all the components for the full build")
-                    .value_name("name")
-                    .default_value("NA"),
+                    .value_name("name"),
             )
             .arg(
                 clap::Arg::new("verbose")


### PR DESCRIPTION
## Summary

Closes #32

This PR removes the 'NA' sentinel default value from the `list` command's `--config` argument and replaces it with a proper Rust `Option<String>` type. Instead of using a magic string value to represent "no config specified," the code now uses idiomatic Rust's `Option` type for better type safety and clarity.

### Changes
- Removed `.default_value("NA")` from the `config` arg definition
- Replaced string-based sentinel pattern with `Option<String>` that directly queries clap matches
- Changed branching logic from `if config == "NA"` to idiomatic `match config { None => ..., Some(name) => ... }`
- All three existing tests (test_cmd_list_build_config, test_cmd_list_invalid_build_config, test_cmd_list_ctx) pass unchanged
- All 261 tests pass, cargo check passes

All acceptance criteria from issue #32 are satisfied.

## Test plan

- [x] Verify all existing tests pass
- [x] Manual testing of `bkry list` with and without `--config` argument

## Squash merge

Remember to squash-merge this PR to maintain clean commit history per repository convention.

Generated with Claude Code