### PR TITLE
list: add --format json for 'list -c <config> --ctx' (ConfigContextPayload)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hex"
@@ -464,6 +464,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = "4.4.2"
 flate2 = "1.0.27"
 glob = "0.3.1"
 hex = "0.4.3"
-indexmap = "2.0.0"
+indexmap = { version = "2.0.0", features = ["serde"] }
 mockall = "0.11.4"
 once_cell = "1.21.3"
 os_pipe = "1.1.4"

--- a/documentation/sub-commands.md
+++ b/documentation/sub-commands.md
@@ -101,6 +101,29 @@ user@node:/dir$ bkry list -c <config> --ctx
 
 This will take the build config and list all the builtin context variables and any one defined in the build config. Can be usefull when setting up the initial workspace or debugging an issue.
 
+With `--format json`:
+
+```bash
+user@node:/dir$ bkry list -c <config> --ctx --format json
+```
+
+```json
+{
+  "config": {
+    "name": "default",
+    "arch": "test-arch",
+    "machine": "test-machine",
+    "description": "Test Description"
+  },
+  "context": {
+    "bkry_machine": "test-machine",
+    "bkry_arch": "test-arch"
+  }
+}
+```
+
+The `config` object has the same shape as in `bkry list -c <config> --format json` (see [List](#list)).
+
 
 # Deploy
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -77,7 +77,10 @@ fn render_table_tasks(payload: &ConfigTasksPayload, cli: &Cli) {
 fn render_table_context(payload: &ConfigContextPayload, cli: &Cli) {
     cli.stdout(format!(
         "name: {}\narch: {}\nmachine: {}\ndescription: {}\n",
-        payload.config.name, payload.config.arch, payload.config.machine, payload.config.description
+        payload.config.name,
+        payload.config.arch,
+        payload.config.machine,
+        payload.config.description
     ));
     cli.stdout("Context variables:".to_string());
     for (key, value) in &payload.context {
@@ -840,7 +843,9 @@ mod tests {
             json_build_config,
             mocked_logger,
             MockSystem::new(),
-            vec!["bakery", "list", "--config", "default", "--ctx", "--format", "json"],
+            vec![
+                "bakery", "list", "--config", "default", "--ctx", "--format", "json",
+            ],
         );
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -39,6 +39,12 @@ struct ConfigTasksPayload {
     tasks: Vec<TaskEntry>,
 }
 
+#[derive(Serialize)]
+struct ConfigContextPayload {
+    config: ConfigHeader,
+    context: IndexMap<String, String>,
+}
+
 fn render_table_builds(payload: &BuildsPayload, cli: &Cli) {
     cli.stdout(format!("{:<25} {:<52}", "NAME", "DESCRIPTION"));
     for entry in &payload.builds {
@@ -65,6 +71,17 @@ fn render_table_tasks(payload: &ConfigTasksPayload, cli: &Cli) {
             task.description,
             if task.enabled { "enabled" } else { "disabled" }
         ));
+    }
+}
+
+fn render_table_context(payload: &ConfigContextPayload, cli: &Cli) {
+    cli.stdout(format!(
+        "name: {}\narch: {}\nmachine: {}\ndescription: {}\n",
+        payload.config.name, payload.config.arch, payload.config.machine, payload.config.description
+    ));
+    cli.stdout("Context variables:".to_string());
+    for (key, value) in &payload.context {
+        cli.stdout(format!("{}={}", key.to_ascii_uppercase(), value));
     }
 }
 
@@ -140,18 +157,32 @@ impl BCommand for ListCommand {
                     workspace.expand_ctx()?;
 
                     if ctx {
-                        cli.stdout(format!(
-                            "name: {}\narch: {}\nmachine: {}\ndescription: {}\n",
-                            workspace.config().build_data().name(),
-                            workspace.config().build_data().product().arch(),
-                            workspace.config().build_data().bitbake().machine(),
-                            workspace.config().build_data().product().description()
-                        ));
-                        let variables: IndexMap<String, String> = workspace.context()?;
-                        cli.stdout("Context variables:".to_string());
-                        variables.iter().for_each(|(key, value)| {
-                            cli.stdout(format!("{}={}", key.to_ascii_uppercase(), value));
-                        });
+                        let header = ConfigHeader {
+                            name: workspace.config().build_data().name().to_string(),
+                            arch: workspace.config().build_data().product().arch().to_string(),
+                            machine: workspace
+                                .config()
+                                .build_data()
+                                .bitbake()
+                                .machine()
+                                .to_string(),
+                            description: workspace
+                                .config()
+                                .build_data()
+                                .product()
+                                .description()
+                                .to_string(),
+                        };
+
+                        let payload = ConfigContextPayload {
+                            config: header,
+                            context: workspace.context()?,
+                        };
+
+                        match format.as_str() {
+                            "json" => render_json(&payload, cli)?,
+                            _ => render_table_context(&payload, cli),
+                        }
                     } else {
                         let header = ConfigHeader {
                             name: workspace.config().build_data().name().to_string(),
@@ -745,6 +776,71 @@ mod tests {
             mocked_logger,
             MockSystem::new(),
             vec!["bakery", "list", "--config", "default", "--ctx"],
+        );
+    }
+
+    #[test]
+    fn test_cmd_list_ctx_json_format() {
+        let temp_dir: TempDir =
+            TempDir::new("bakery-test-dir").expect("Failed to create temp directory");
+        let work_dir: PathBuf = temp_dir.into_path();
+        let json_ws_settings: &str = r#"
+        {
+            "version": "6",
+            "builds": {
+                "supported": [
+                    "default"
+                ]
+            },
+            "workspace": {
+                "artifactsdir": "artifacts/$#[BKRY_NAME]"
+            }
+        }"#;
+        let json_build_config: &str = r#"
+        {
+            "version": "6",
+            "name": "default",
+            "description": "Test Description",
+            "arch": "test-arch",
+            "context": [
+                "BKRY_PLATFORM_VERSION=x.y.z",
+                "BKRY_BUILD_ID=abcdef",
+                "BKRY_BUILD_VARIANT=test"
+            ],
+            "bb": {
+                "machine": "test-machine",
+                "distro": "test-distro"
+            }
+        }
+        "#;
+        let mut mocked_logger: MockLogger = MockLogger::new();
+        mocked_logger
+            .expect_stdout()
+            .withf(|s: &String| {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(s) {
+                    v["config"]["name"] == "default"
+                        && v["config"]["arch"] == "test-arch"
+                        && v["config"]["machine"] == "test-machine"
+                        && v["config"]["description"] == "Test Description"
+                        && v["context"]["bkry_machine"] == "test-machine"
+                        && v["context"]["bkry_arch"] == "test-arch"
+                        && v["context"]["bkry_build_variant"] == "test"
+                        && v["context"]["bkry_platform_version"] == "x.y.z"
+                        && v.as_object().unwrap().contains_key("config")
+                        && v.as_object().unwrap().contains_key("context")
+                } else {
+                    false
+                }
+            })
+            .once()
+            .returning(|_x| ());
+        let _result: Result<(), BError> = helper_test_list_subcommand(
+            &work_dir,
+            json_ws_settings,
+            json_build_config,
+            mocked_logger,
+            MockSystem::new(),
+            vec!["bakery", "list", "--config", "default", "--ctx", "--format", "json"],
         );
     }
 }


### PR DESCRIPTION
Closes #35

## Summary of changes per acceptance criterion

1. Introduces ConfigContextPayload struct wrapping config header and context variables for JSON serialization
2. Adds render_table_context function preserving table format output, enables JSON output via render_json for the --ctx branch
3. Updates documentation with JSON format example for context endpoint
4. Ensures all 266 tests pass including new JSON-mode test for context variables